### PR TITLE
Fix Issue Schema's `page_count` field

### DIFF
--- a/grayven/schemas/issue.py
+++ b/grayven/schemas/issue.py
@@ -11,6 +11,7 @@ __all__ = ["BasicIssue", "Issue", "Story", "StoryType"]
 
 import re
 from datetime import date
+from decimal import Decimal
 from enum import Enum
 from typing import Annotated, Optional
 
@@ -64,7 +65,7 @@ class Story(BaseModel):
     job_number: Annotated[Optional[str], BeforeValidator(blank_is_none)]
     letters: Annotated[Optional[str], BeforeValidator(blank_is_none)]
     notes: Annotated[Optional[str], BeforeValidator(blank_is_none)]
-    page_count: str
+    page_count: Optional[Decimal]
     pencils: str
     script: Annotated[Optional[str], BeforeValidator(blank_is_none)]
     sequence_number: int
@@ -89,7 +90,7 @@ class BasicIssue(BaseModel):
 
     api_url: HttpUrl
     descriptor: str
-    page_count: str
+    page_count: Optional[Decimal]
     price: str
     publication_date: str
     series: HttpUrl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ docs = [
 tests = [
   "pytest >= 8.3.4",
   "pytest-cov >= 6.0.0",
+  "pytest-httpx>=0.35.0",
   "tox >= 4.23.2",
   "tox-uv >= 1.16.2"
 ]

--- a/tests/issue_test.py
+++ b/tests/issue_test.py
@@ -4,6 +4,7 @@ This module contains tests for Issue and BasicIssue objects.
 """
 
 from datetime import date
+from decimal import Decimal
 
 import pytest
 
@@ -23,7 +24,7 @@ def test_issue(session: GrandComicsDatabase) -> None:
     assert result.descriptor == "1 [Direct Sales - Carlos Pacheco / Jesus Merino Cover]"
     assert result.publication_date == "July 2005"
     assert result.price == "3.50 USD; 4.75 CAD"
-    assert result.page_count == "48.000"
+    assert result.page_count == Decimal("48")
     assert (
         result.editing
         == "Peter J. Tomasi (credited as  Peter Tomasi) (editor); Harvey Richards (credited) (assistant editor); Dan DiDio (credited) (executive editor); Paul Levitz (credited) (publisher)"  # noqa: E501
@@ -42,7 +43,7 @@ def test_issue(session: GrandComicsDatabase) -> None:
     assert result.story_set[0].title is None
     assert result.story_set[0].feature == "Green Lantern"
     assert result.story_set[0].sequence_number == 0
-    assert result.story_set[0].page_count == "1.000"
+    assert result.story_set[0].page_count == Decimal("1")
     assert result.story_set[0].script is None
     assert result.story_set[0].pencils == "Carlos Pacheco (credited) (signed as Pacheco [scratch])"
     assert result.story_set[0].inks == "Jesús Merino (credited) (signed as Merino)"

--- a/tests/issue_test.py
+++ b/tests/issue_test.py
@@ -116,7 +116,7 @@ def test_list_issues(session: GrandComicsDatabase) -> None:
     assert result.descriptor == "1 [Direct Sales - Carlos Pacheco / Jesus Merino Cover]"
     assert result.publication_date == "July 2005"
     assert result.price == "3.50 USD; 4.75 CAD"
-    assert result.page_count == "48.000"
+    assert result.page_count == Decimal("48")
     assert result.variant_of is None
     assert str(result.series) == "https://www.comics.org/api/series/13519/?format=json"
 

--- a/tests/issue_test.py
+++ b/tests/issue_test.py
@@ -7,10 +7,48 @@ from datetime import date
 from decimal import Decimal
 
 import pytest
+from pytest_httpx import HTTPXMock
 
 from grayven.exceptions import ServiceError
 from grayven.grand_comics_database import GrandComicsDatabase
-from grayven.schemas.issue import StoryType
+from grayven.schemas.issue import Issue, StoryType
+
+
+@pytest.fixture
+def issue_no_page_json() -> dict[str, any]:
+    """Simple fixture for issue with no page."""
+    return {
+        "api_url": "https://www.comics.org/api/issue/2698986/?format=json",
+        "series_name": "Cruel Kingdom (2025 series)",
+        "descriptor": "1",
+        "publication_date": "January 2025",
+        "price": "4.99 USD",
+        "page_count": None,
+        "editing": "",
+        "indicia_publisher": "Oni-Lion Forge Publishing Group, LLC",
+        "brand": "EC An Entertaining Comic; Oni Press [eye]",
+        "isbn": "",
+        "barcode": "64985600823700111",
+        "rating": "",
+        "on_sale_date": "2025-01-08",
+        "indicia_frequency": "",
+        "notes": "",
+        "variant_of": None,
+        "series": "https://www.comics.org/api/series/219801/?format=json",
+        "story_set": [],
+        "cover": "https://files1.comics.org//img/gcd/covers_by_id/1743/w400/1743127.jpg",
+    }
+
+
+def test_issue_no_page(httpx_mock: HTTPXMock, issue_no_page_json: dict[str, any]) -> None:
+    """Test issue with no page count."""
+    session = GrandComicsDatabase()  # We don't want to cache these results
+    httpx_mock.add_response(json=issue_no_page_json)
+    result = session.get_issue(2698986)
+    assert isinstance(result, Issue)
+    assert result.page_count is None
+    assert result.descriptor == "1"
+    assert result.publication_date == "January 2025"
 
 
 def test_issue(session: GrandComicsDatabase) -> None:


### PR DESCRIPTION
This PR changes the Issue's schema `page_count` field from a `str` to `Optional[Decimal]`, the test for this shouldn't cache the response, since it's *very* likely to change.